### PR TITLE
Exclude Ruby files in node_modules

### DIFF
--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -15,9 +15,10 @@ AllCops:
     - "bin/*"
     - "db/schema.rb"
     - "lib/templates/**/*"
+    - "**/node_modules/**/*"
     - "tmp/**/*"
     - "vendor/**/*"
-    - "log/**/*"  
+    - "log/**/*"
 
 #
 # Ruby Cops


### PR DESCRIPTION
Rubocop got hung up on a file in `node_modules/rails-erb-loader`. We should ignore this whole directory for the same reasons we ignore vendor.

I tried this config:

```yml
inherit_from:
  - https://raw.githubusercontent.com/carbonfive/c5-conventions/master/rubocop/rubocop.yml

AllCops:
  TargetRubyVersion: 2.4
  Exclude:
    - 'node_modules/**/*'
```

As far as I can tell, the `Exclude` config does **not** add to the inherited rules, and actually overwrites them. So trying to use this config means that Rubocop will actually check `bin/*`, `db/schema`, etc.

Is it reasonable enough to expect you would have node modules in a rails project?