### PR TITLE
Disable Layout/AlignHash

### DIFF
--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -24,6 +24,9 @@ AllCops:
 # Ruby Cops
 #
 
+Layout/AlignHash:
+  Enabled: false
+
 Layout/CaseIndentation:
   Enabled: false
 


### PR DESCRIPTION
Rubocop 0.60 has changed the default behavior of Layout/AlignHash so that you are unable to mix styles on how you [align multi-line hashes](https://docs.rubocop.org/en/latest/cops_layout/#layoutalignhash).

We can disable this cop until a more flexible option becomes available (https://github.com/rubocop-hq/rubocop/issues/6410).