### PR TITLE
Remove reference to performance cop

### DIFF
--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -71,9 +71,6 @@ Metrics/MethodLength:
 Naming/PredicateName:
   Enabled: false
 
-Performance/Casecmp:
-  Enabled: false
-
 Security/YAMLLoad:
   Enabled: false
 


### PR DESCRIPTION
Performance cops were [moved out in to their own gem in Rubocop 0.68], which
means that referring to them in our default `.rubocop.yml` will log a warning like,

```
Warning: unrecognized cop Performance/Casecmp found in .rubocop-https---raw-githubusercontent[…]
```

when rubocop is run.

To resolve this we can either:
* Remove the reference to the performance cop. 
* Add the new gem `rubocop-performance` as a dependency in Raygun, and add `require: rubocop-performance` to our default `.rubocop.yml`.

Removing the reference seems like the lower impact change, but it may negatively impact users who do not upgrade to 0.68, as this previously disabled Performace/Casecmp cop will now be enabled until they upgrade to 0.68.

[moved out in to their own gem in Rubocop 0.68]: https://github.com/rubocop-hq/rubocop/issues/5977