### PR TITLE
Fix renamed cops

### DIFF
--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -25,14 +25,14 @@ AllCops:
 # Ruby Cops
 #
 
-Layout/AlignHash:
-  Enabled: false
-
 Layout/CaseIndentation:
   Enabled: false
 
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
+
+Layout/HashAlignment:
+  Enabled: false
 
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented


### PR DESCRIPTION
Layout/Align hash was renamed (#7) in Rubocop v0.77 (https://github.com/rubocop-hq/rubocop/issues/7077).

Change our conventions accordingly.