### PR TITLE
Add reference to `rubocop-rails` so we can use the Rails cops

### DIFF
--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -7,7 +7,9 @@
 # See http://rubocop.readthedocs.io/en/latest/configuration/#inheriting-configuration-from-a-remote-url for details.
 #
 
-require: rubocop-performance
+require:
+  - rubocop-performance
+  - rubocop-rails
 
 AllCops:
   DisplayCopNames: true


### PR DESCRIPTION
Problem
-----------

We had specified some Rails cop rules at the bottom of `rubocop.yml` but we
did not include the `rubocop-rails` rules at the top so `rubocop` was complaining:

```
Error: unrecognized cop Rails/ApplicationRecord found in .rubocop.yml, unrecognized cop Rails/HasAndBelongsToMany found in .rubocop.yml, unrecognized cop Rails/RakeEnvironment found in .rubocop.yml
```

Solution
-----------
Add to the `require` line `rubocop-rails` so those cops will be defined before we read the rubocop.yml file.

Note:  this means projects that include this file *may* need to add `rubocop-rails` to their Gemfiles