### PR TITLE
Metrics/LineLength has the wrong namespace - should be Layout

### DIFF
--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -34,6 +34,9 @@ Layout/FirstArrayElementIndentation:
 Layout/HashAlignment:
   Enabled: false
 
+Layout/LineLength:
+  Max: 120
+
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
@@ -60,9 +63,6 @@ Metrics/ClassLength:
   Max: 250
   Exclude:
     - "spec/**/*"
-
-Metrics/LineLength:
-  Max: 120
 
 Metrics/MethodLength:
   Max: 25


### PR DESCRIPTION
Problem
-----------
As of Rubocop 0.78 (https://github.com/rubocop-hq/rubocop/releases/tag/v0.78.0), LineLength is now under the Layout department/namespace.

Solution
-----------
Update `.rubocop.yml` to reflect that namespace change.