### PR TITLE
Remove unnecessary header from rubocop file

### DIFF
--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -1,12 +1,3 @@
-# Configuration hierarchy:
-#
-# 1. Rubocop defaults
-# 2. Carbon Five defaults (this file)
-# 3. Project overrides
-#
-# See http://rubocop.readthedocs.io/en/latest/configuration/#inheriting-configuration-from-a-remote-url for details.
-#
-
 require:
   - rubocop-performance
   - rubocop-rails


### PR DESCRIPTION
In practice, going forward the .rubocop.yml file in this repo will be copied into projects that use it. That means the comment at the top of the file is inaccurate.

We'll just take it out and let developers read the rubocop docs if they need more info.

Fixes #12