### PR TITLE
Add new style cops from Rubocop v0.80 (Style/HashTransformKeys, Style/HashTransformValues, Style/HashEachMethods)

### DIFF
--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -86,7 +86,16 @@ Style/EmptyMethod:
 
 Style/FrozenStringLiteralComment:
   EnforcedStyle: never
-
+  
+Style/HashEachMethods:
+  Enabled: true
+  
+Style/HashTransformKeys:
+  Enabled: true
+  
+Style/HashTransformValues:
+  Enabled: true
+  
 Style/Lambda:
   EnforcedStyle: literal
 


### PR DESCRIPTION
Running our config with rubocop v0.80 outputs the following warning,

```
The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file:
 - Style/HashEachMethods
 - Style/HashTransformKeys
 - Style/HashTransformValues
```

I'm not sure why they aren't enabled/disabled by default (is this a new rubocop thing/something project specific?)

Anyway, assuming it's just how they release new cops now, these seem like good cops, so let's enable them by default.