### PR TITLE
Proposed C5 conventions for configuring rubocop-rspec

### DIFF
--- a/rubocop/rubocop_rspec.yml
+++ b/rubocop/rubocop_rspec.yml
@@ -1,0 +1,28 @@
+require:
+  - rubocop-rspec
+
+# Request and system specs by definition do not test specific classes/modules,
+# so they are excluded from following the `describe ClassOrModule` rule.
+RSpec/DescribeClass:
+  Exclude:
+    - "spec/requests/**/*"
+    - "spec/system/**/*"
+
+# Prefer short examples but allow some flexibility (up to 12 lines). System
+# specs are excluded from this cop because they often involve many sequential
+# steps, and forcing these to be shorter can make them harder to follow.
+RSpec/ExampleLength:
+  Max: 12 # Default is 5
+  Exclude:
+    - "spec/system/**/*"
+
+# Prefer simple, single-statement examples be collapsed to 1 line like this:
+# it { is_expected.to be_truthy }
+RSpec/ImplicitSubject:
+  EnforcedStyle: single_statement_only
+
+# Ideal BDD is to have one `expect` per example (so that each specification can
+# have corresponding documentation in the form of an `it` block), but we allow
+# some flexibility (up to 3).
+RSpec/MultipleExpectations:
+  Max: 3 # Default is 1

--- a/rubocop/rubocop_rspec.yml
+++ b/rubocop/rubocop_rspec.yml
@@ -5,6 +5,7 @@ require:
 # so they are excluded from following the `describe ClassOrModule` rule.
 RSpec/DescribeClass:
   Exclude:
+    - "spec/features/**/*"
     - "spec/requests/**/*"
     - "spec/system/**/*"
 
@@ -14,6 +15,7 @@ RSpec/DescribeClass:
 RSpec/ExampleLength:
   Max: 12 # Default is 5
   Exclude:
+    - "spec/features/**/*"
     - "spec/system/**/*"
 
 # If an `it` block does not have a description (i.e. the example relies on
@@ -30,4 +32,5 @@ RSpec/ImplicitSubject:
 RSpec/MultipleExpectations:
   Max: 3 # Default is 1
   Exclude:
+    - "spec/features/**/*"
     - "spec/system/**/*"

--- a/rubocop/rubocop_rspec.yml
+++ b/rubocop/rubocop_rspec.yml
@@ -25,6 +25,9 @@ RSpec/ImplicitSubject:
 
 # Ideal BDD is to have one `expect` per example (so that each specification can
 # have corresponding documentation in the form of an `it` block), but we allow
-# some flexibility (up to 3).
+# some flexibility (up to 3). System specs are often long capybara flows with
+# many expectations, so we exclude them from this cop.
 RSpec/MultipleExpectations:
   Max: 3 # Default is 1
+  Exclude:
+    - "spec/system/**/*"

--- a/rubocop/rubocop_rspec.yml
+++ b/rubocop/rubocop_rspec.yml
@@ -16,7 +16,9 @@ RSpec/ExampleLength:
   Exclude:
     - "spec/system/**/*"
 
-# Prefer simple, single-statement examples be collapsed to 1 line like this:
+# If an `it` block does not have a description (i.e. the example relies on
+# RSpec magic to infer the description), then prefer it use the `is_expected`
+# syntax instead of `expect(subject)`, like this:
 # it { is_expected.to be_truthy }
 RSpec/ImplicitSubject:
   EnforcedStyle: single_statement_only


### PR DESCRIPTION
I'm using rubocop-rspec a current project and have been pleased with the results. This PR ports my team's learnings back to the C5 conventions so that they can hopefully benefit future C5 Rails projects.

In general the out-of-the-box rubocop-rspec rules lead to more consistent, easier to read specs. There are a few rules that I've relaxed a bit for convenience.

The only significant departure from the defaults is for request/system specs. Our style of writing system specs is to mimic how a user would interact with the app, which usually involves taking several steps: clicking links, filling out form fields, etc. This isn't really compatible with RuboCop's preference for extremely short examples.