### PR TITLE
Style/TernaryParentheses: require_parentheses_when_complex

### DIFF
--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -117,6 +117,9 @@ Style/StringLiteralsInInterpolation:
 Style/StructInheritance:
   Enabled: true
 
+Style/TernaryParentheses:
+  EnforcedStyle: require_parentheses_when_complex
+
 #
 # Rails Cops
 #


### PR DESCRIPTION
I try not to use the ternary very often, and when I do, I try to make sure it's a "simple" expression so that it's readable. However, sometimes -- in times of weakness perhaps -- I write a "complex" ternary.

The default rubocop rule strips ternaries of their parentheses. I propose switching to the `require_parentheses_when_complex` setting, which requires parentheses when it's a multi-part expression.

Here's a real-world example with the **default** setting:

```ruby
carve_out.present? && carve_out > 0 ? "~ #{carve_out} hours" : "-"
```

Same example with `require_parentheses_when_complex`:

```ruby
(carve_out.present? && carve_out > 0) ? "~ #{carve_out} hours" : "-"
```

See https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/TernaryParentheses for additional details.