### PR TITLE
Enable new cops added in rubocop 0.81 through 0.85

### DIFF
--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -21,6 +21,9 @@ AllCops:
 Layout/CaseIndentation:
   Enabled: false
 
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true
+
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
@@ -33,12 +36,27 @@ Layout/LineLength:
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
 Lint/AmbiguousBlockAssociation:
   Enabled: false
+
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: true
+
+Lint/MixedRegexpCaptureTypes:
+  Enabled: true
+
+Lint/RaiseException:
+  Enabled: true
 
 Lint/ScriptPermission:
   Exclude:
     - "Rakefile"
+
+Lint/StructNewOverride:
+  Enabled: true
 
 Metrics/AbcSize:
   Max: 35
@@ -84,18 +102,21 @@ Style/Documentation:
 Style/EmptyMethod:
   EnforcedStyle: expanded
 
+Style/ExponentialNotation:
+  Enabled: true
+
 Style/FrozenStringLiteralComment:
   EnforcedStyle: never
-  
+
 Style/HashEachMethods:
   Enabled: true
-  
+
 Style/HashTransformKeys:
   Enabled: true
-  
+
 Style/HashTransformValues:
   Enabled: true
-  
+
 Style/Lambda:
   EnforcedStyle: literal
 
@@ -107,6 +128,15 @@ Style/MutableConstant:
 
 Style/PreferredHashMethods:
   Enabled: false
+
+Style/RedundantRegexpCharacterClass:
+  Enabled: true
+
+Style/RedundantRegexpEscape:
+  Enabled: true
+
+Style/SlicingWithRange:
+  Enabled: true
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes


### PR DESCRIPTION
Rubocop now forces us to explicitly opt in or opt out to new cops when they are added to the rubocop gem. There are several cops that have been added since 0.80. All of them seem like no-brainers to enable.

This fixes the following warning when running rubocop 0.85:

```
The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file:
 - Layout/EmptyLinesAroundAttributeAccessor (0.83)
 - Layout/SpaceAroundMethodCallOperator (0.82)
 - Lint/DeprecatedOpenSSLConstant (0.84)
 - Lint/MixedRegexpCaptureTypes (0.85)
 - Lint/RaiseException (0.81)
 - Lint/StructNewOverride (0.81)
 - Style/ExponentialNotation (0.82)
 - Style/RedundantRegexpCharacterClass (0.85)
 - Style/RedundantRegexpEscape (0.85)
 - Style/SlicingWithRange (0.83)
For more information: https://docs.rubocop.org/rubocop/versioning.html
```