### PR TITLE
Add Style/RedundantFetchBlock introduced in 0.86.0

### DIFF
--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -129,6 +129,9 @@ Style/MutableConstant:
 Style/PreferredHashMethods:
   Enabled: false
 
+Style/RedundantFetchBlock:
+  Enabled: true
+
 Style/RedundantRegexpCharacterClass:
   Enabled: true
 


### PR DESCRIPTION
This rule flags the following uses of `Hash#fetch`:

```
config/puma.rb:7:25: C: Style/RedundantFetchBlock: Use fetch("RAILS_MAX_THREADS", 5) instead of fetch("RAILS_MAX_THREADS") { 5 }. (https://github.com/JuanitoFatas/fast-ruby#hashfetch-with-argument-vs-hashfetch--block-code)
max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
config/puma.rb:13:17: C: Style/RedundantFetchBlock: Use fetch("PORT", 3000) instead of fetch("PORT") { 3000 }. (https://github.com/JuanitoFatas/fast-ruby#hashfetch-with-argument-vs-hashfetch--block-code)
port        ENV.fetch("PORT") { 3000 }
                ^^^^^^^^^^^^^^^^^^^^^^
config/puma.rb:29:21: C: Style/RedundantFetchBlock: Use fetch("WEB_CONCURRENCY", 1) instead of fetch("WEB_CONCURRENCY") { 1 }. (https://github.com/JuanitoFatas/fast-ruby#hashfetch-with-argument-vs-hashfetch--block-code)
workers_count = ENV.fetch("WEB_CONCURRENCY") { 1 }.to_i
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```