### PR TITLE
Enable new cops by default

### DIFF
--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -3,6 +3,7 @@ require:
   - rubocop-rails
 
 AllCops:
+  NewCops: enable
   DisplayCopNames: true
   DisplayStyleGuide: true
   Exclude:

--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -22,9 +22,6 @@ AllCops:
 Layout/CaseIndentation:
   Enabled: false
 
-Layout/EmptyLinesAroundAttributeAccessor:
-  Enabled: true
-
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
@@ -37,27 +34,12 @@ Layout/LineLength:
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
-Layout/SpaceAroundMethodCallOperator:
-  Enabled: true
-
 Lint/AmbiguousBlockAssociation:
   Enabled: false
-
-Lint/DeprecatedOpenSSLConstant:
-  Enabled: true
-
-Lint/MixedRegexpCaptureTypes:
-  Enabled: true
-
-Lint/RaiseException:
-  Enabled: true
 
 Lint/ScriptPermission:
   Exclude:
     - "Rakefile"
-
-Lint/StructNewOverride:
-  Enabled: true
 
 Metrics/AbcSize:
   Max: 35
@@ -103,20 +85,8 @@ Style/Documentation:
 Style/EmptyMethod:
   EnforcedStyle: expanded
 
-Style/ExponentialNotation:
-  Enabled: true
-
 Style/FrozenStringLiteralComment:
   EnforcedStyle: never
-
-Style/HashEachMethods:
-  Enabled: true
-
-Style/HashTransformKeys:
-  Enabled: true
-
-Style/HashTransformValues:
-  Enabled: true
 
 Style/Lambda:
   EnforcedStyle: literal
@@ -130,23 +100,11 @@ Style/MutableConstant:
 Style/PreferredHashMethods:
   Enabled: false
 
-Style/RedundantRegexpCharacterClass:
-  Enabled: true
-
-Style/RedundantRegexpEscape:
-  Enabled: true
-
-Style/SlicingWithRange:
-  Enabled: true
-
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
-
-Style/StructInheritance:
-  Enabled: true
 
 Style/TernaryParentheses:
   EnforcedStyle: require_parentheses_when_complex


### PR DESCRIPTION
Robocop can now automatically enable new cops/rules be default.

This seems like a good default so that new rules are enabled and can be evaluated easily, tweaked, or disabled.