### PR TITLE
Refactor rubocop config into separate files and provide installation instructions

### DIFF
--- a/rubocop/.rubocop-common.yml
+++ b/rubocop/.rubocop-common.yml
@@ -1,7 +1,3 @@
-require:
-  - rubocop-performance
-  - rubocop-rails
-
 AllCops:
   NewCops: enable
   DisplayCopNames: true
@@ -14,10 +10,6 @@ AllCops:
     - "tmp/**/*"
     - "vendor/**/*"
     - "log/**/*"
-
-#
-# Ruby Cops
-#
 
 Layout/CaseIndentation:
   Enabled: false
@@ -67,9 +59,6 @@ Metrics/MethodLength:
 Naming/PredicateName:
   Enabled: false
 
-Performance/Casecmp:
-  Enabled: false
-
 Security/YAMLLoad:
   Enabled: false
 
@@ -108,17 +97,3 @@ Style/StringLiteralsInInterpolation:
 
 Style/TernaryParentheses:
   EnforcedStyle: require_parentheses_when_complex
-
-#
-# Rails Cops
-#
-
-Rails/ApplicationRecord:
-  Exclude:
-    - "db/migrate/**"
-
-Rails/HasAndBelongsToMany:
-  Enabled: false
-
-Rails/RakeEnvironment:
-  Enabled: false

--- a/rubocop/.rubocop-performance.yml
+++ b/rubocop/.rubocop-performance.yml
@@ -1,0 +1,2 @@
+Performance/Casecmp:
+  Enabled: false

--- a/rubocop/.rubocop-rails.yml
+++ b/rubocop/.rubocop-rails.yml
@@ -1,0 +1,9 @@
+Rails/ApplicationRecord:
+  Exclude:
+    - "db/migrate/**"
+
+Rails/HasAndBelongsToMany:
+  Enabled: false
+
+Rails/RakeEnvironment:
+  Enabled: false

--- a/rubocop/.rubocop-rspec.yml
+++ b/rubocop/.rubocop-rspec.yml
@@ -1,6 +1,3 @@
-require:
-  - rubocop-rspec
-
 # Request and system specs by definition do not test specific classes/modules,
 # so they are excluded from following the `describe ClassOrModule` rule.
 RSpec/DescribeClass:

--- a/rubocop/.rubocop.yml
+++ b/rubocop/.rubocop.yml
@@ -1,0 +1,10 @@
+require:
+  - rubocop-performance
+  - rubocop-rails
+  - rubocop-rspec
+
+inherit_from:
+  - ./.rubocop-common.yml
+  - ./.rubocop-performance.yml
+  - ./.rubocop-rails.yml
+  - ./.rubocop-rspec.yml

--- a/rubocop/README.md
+++ b/rubocop/README.md
@@ -1,0 +1,46 @@
+# Carbon Five Rubocop Conventions
+
+We like and recommend Rubocop, with the caveat that a handful of its rules can be overly strict out of the box. We've found that development teams benefit from relaxing some of the default settings in order to remove unnecessary friction. This directory contains the configuration we consider standard practice for all of our internal Ruby code bases and a good starting point for starting greenfield client projects.
+
+## Installation
+
+### Making your own copy (recommended!)
+
+The safest way to use the standard Carbon Five Rubocop configuration is to copy all the `.rubocop*.yml` files from this repo into your project. Here is a quick way to do it with `wget`:
+
+```
+cd my-rails-app
+wget https://raw.githubusercontent.com/carbonfive/c5-conventions/main/rubocop/.rubocop{,-common,-performance,-rails,-rspec}.yml
+```
+
+#### Without Rails
+
+The default `.rubocop.yml` assumes you are using Rails, but you can also pick and choose from the individual files that apply to your project. For example, if you aren't using Rails or Rspec, copy the other files that matter to you and construct your own `.rubocop.yml` configuration, like this:
+
+```yaml
+require:
+  - rubocop-performance
+
+inherit_from:
+  - ./.rubocop-common.yml      # copied from c5-conventions
+  - ./.rubocop-performance.yml # copied from c5-conventions
+```
+
+### Inheriting directly from this repo
+
+Alternatively, if you want your project's configuration to always be exactly in sync with the latest C5 conventions, create a `.rubocop.yml` file in your project:
+
+```yaml
+require:
+  - rubocop-performance
+  - rubocop-rails
+  - rubocop-rspec
+
+inherit_from:
+  - https://raw.githubusercontent.com/carbonfive/c5-conventions/main/rubocop/.rubocop-common.yml
+  - https://raw.githubusercontent.com/carbonfive/c5-conventions/main/rubocop/.rubocop-performance.yml
+  - https://raw.githubusercontent.com/carbonfive/c5-conventions/main/rubocop/.rubocop-rails.yml
+  - https://raw.githubusercontent.com/carbonfive/c5-conventions/main/rubocop/.rubocop-rspec.yml
+```
+
+:warning: If you inherit directly from c5-conventions like this, your Rubocop configuration will be subject to change without notice! We may alter the configuration in ways that cause your project to suddenly be out of compliance.


### PR DESCRIPTION
## Problem

Before, the `rubocop.yml` included rails and performance cops, which meant that it could only be used in certain projects.

Additionally, it was hard to copy the recommended config into a new Rails project. The `rubocop.yml` could be copied and would work right out of the box, but using the separate `rubocop_rspec.yml` file was not straightforward. It was not as simple as just concatenating the two files together. That meant it would be hard to automate this step when generating projects in raygun.

## Solution

Fix by splitting up the configuration into a separate `.yml` file per rubocop plugin, so that downstream consumers can pick and choose the ones they want.

The typical use case still assumes you want all of the config (i.e. including rails, performance, and rspec), so provide a top-level `.rubocop.yml` that includes them all. So now you can just copy down all the files and be good to go.

If you have a more specialized use case you can create your own `.rubocop.yml` and pull just the pieces that you need.

Add a `README.md` to explain how this works.

The instructions assume we will be renaming the default branch of this repo to `main`. We can keep `master` around so we don't break downstream projects that still link to it.