### PR TITLE
Deprecate the master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# C5 Conventions
+## :warning: Please use the [main](https://github.com/carbonfive/c5-conventions/) branch instead
 
-An *experimental* set of configuration for various code convention enforcers, linters, and the like.
+**The contents of the `master` branch will no longer receive updates and this branch will eventually be deleted.** If you are using `inherit_from` in Rubocop to pull directly from this repository, please update your references to point to `main` instead.


### PR DESCRIPTION
We are keeping the `master` branch around so that we don't break downstream projects that still depend on it. But we want to deprecate it going forward. This PR replaces the README on the `master` branch to direct people to go to the new default branch.

Note this PR will merge into `master`, not `main`.