### PR TITLE
Enable some kind of hash alignment

### DIFF
--- a/rubocop/.rubocop-common.yml
+++ b/rubocop/.rubocop-common.yml
@@ -18,7 +18,12 @@ Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
 Layout/HashAlignment:
-  Enabled: false
+  EnforcedColonStyle:
+    - key
+    - table
+  EnforcedHashRocketStyle:
+    - key
+    - table
 
 Layout/LineLength:
   Max: 120


### PR DESCRIPTION
# Details

I found this existing combination of rubocop rules to be an awkward combination:
```
Enabled: Layout/FirstArgumentIndentation
Enabled: Layout/FirstHashElementIndentation
Disabled: Layout/HashAlignment
```

This leads to some indentation scenarios that aren't considered violations:

```ruby
# not auto-corrected because the first line satisfies 
# Example 1 - Layout/FirstArgumentIndentation
expect(ThisCommand).to have_received(:call).with(
  foo: anything,
    bar: anything
)

# Example 2 - Layout/FirstHashElementIndentation
it "tests the command" do
  expect(call_command).to include({
                                foo: "foo",
    bar: "bar"
                              })
end
```

I enable the HashAlignment rule to allow `key` format (keep hash keys aligned) and `table` format (keep hash rockets aligned), while preferring key alignment when given a choice to autocorrect.