### PR TITLE
Loosen description of rake task tests

### DIFF
--- a/rubocop/.rubocop-rspec.yml
+++ b/rubocop/.rubocop-rspec.yml
@@ -5,6 +5,7 @@ RSpec/DescribeClass:
     - "spec/features/**/*"
     - "spec/requests/**/*"
     - "spec/system/**/*"
+    - "spec/tasks/**/*"
 
 # Prefer short examples but allow some flexibility (up to 12 lines). System
 # specs are excluded from this cop because they often involve many sequential


### PR DESCRIPTION
On occasions where we test rake tasks, there's no class name to reference. In the `describe` block we usually reference how you would execute the task:

```rb
RSpec.describe "rake name_of_task" do
  # ...
end
```

This PR extends our ignore list to rake tasks.