### PR TITLE
Enable ActiveSupport extensions in rubocop

### DIFF
--- a/rubocop/.rubocop-rails.yml
+++ b/rubocop/.rubocop-rails.yml
@@ -1,3 +1,6 @@
+AllCops:
+  ActiveSupportExtensionsEnabled: true
+
 Rails/ApplicationRecord:
   Exclude:
     - "db/migrate/**"


### PR DESCRIPTION
Rubocop 1.31.0 introduced some new rules that can catch mistakes related specifically to ActiveSupport extensions like `Object#in?`. This commit opts us into these rules.

ActiveSupport is part of Rails, which is why I placed this inside the `.rubocop-rails.yml` config file.