### PR TITLE
Improve rubocop auto-correct for array and argument wrapping

### DIFF
--- a/rubocop/.rubocop-common.yml
+++ b/rubocop/.rubocop-common.yml
@@ -17,6 +17,15 @@ Layout/CaseIndentation:
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
+Layout/FirstArrayElementLineBreak:
+  Enabled: true
+
+Layout/FirstHashElementLineBreak:
+  Enabled: true
+
+Layout/FirstMethodArgumentLineBreak:
+  Enabled: true
+
 Layout/HashAlignment:
   EnforcedColonStyle:
     - key
@@ -27,6 +36,15 @@ Layout/HashAlignment:
 
 Layout/LineLength:
   Max: 120
+
+Layout/MultilineArrayLineBreaks:
+  Enabled: true
+
+Layout/MultilineHashKeyLineBreaks:
+  Enabled: true
+
+Layout/MultilineMethodArgumentLineBreaks:
+  Enabled: true
 
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented


### PR DESCRIPTION
# Problem

Out of the box, when a line of ruby code exceeds rubocop's maximum line length, rubocop's auto-corrections produce code wrapping that is ugly and hard to read.

For example, this code:

```ruby
def example
  an_array_of_importance = ["Nisl venenatis, massa tempus tortor, arcu blandit.", "Diam posuere at in lectus ipsum ultrices erat.", "Senectus bibendum eu odio cras."]

  call_a_method_with_many_arguments("this is long argument number 1", an_array_of_importance, are_you_sure: "yes", force: true)
end
```

Is auto-corrected to:

```ruby
def example
  an_array_of_importance = ["Nisl venenatis, massa tempus tortor, arcu blandit.",
                            "Diam posuere at in lectus ipsum ultrices erat.", "Senectus bibendum eu odio cras."]

  call_a_method_with_many_arguments("this is long argument number 1", an_array_of_importance, are_you_sure: "yes",
                                                                                              force: true)
end
```

Notice how rubocop left `force: true` hanging in the middle of nowhere at the end of a long line of white space.

# Solution

This PR changes various rubocop settings so that when lines are very long, rubocop will prefer wrapping onto one line per array element/arg/parameter. This is easier to read and also much more similar to how JS/TS code is wrapped by Prettier.

Now `rubocop -a` will produce this result:

```ruby
def example
  an_array_of_importance = [
    "Nisl venenatis, massa tempus tortor, arcu blandit.",
    "Diam posuere at in lectus ipsum ultrices erat.",
    "Senectus bibendum eu odio cras."
  ]

  call_a_method_with_many_arguments(
    "this is long argument number 1",
    an_array_of_importance,
    are_you_sure: "yes",
    force: true
  )
end
```

I've tested these configuration changes against the raygun-rails repo, and `rubocop -a` produced zero changes, so it won't break the build downstream.