### PR TITLE
Remove unneeded ActiveSupportExtensionsEnabled rubocop setting

### DIFF
--- a/rubocop/.rubocop-rails.yml
+++ b/rubocop/.rubocop-rails.yml
@@ -1,6 +1,3 @@
-AllCops:
-  ActiveSupportExtensionsEnabled: true
-
 Rails/ApplicationRecord:
   Exclude:
     - "db/migrate/**"


### PR DESCRIPTION
As of rubocop-rails 2.16.0, `ActiveSupportExtensionsEnabled` is automatically set to true, so this setting now redundant and can be removed.

Ref: https://github.com/rubocop/rubocop-rails/blob/master/CHANGELOG.md#2160-2022-09-09